### PR TITLE
Implement test suite for Cloud Run classifier

### DIFF
--- a/cloud-run-app/Dockerfile
+++ b/cloud-run-app/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app.py .
+
+CMD ["python", "app.py"]

--- a/cloud-run-app/README.md
+++ b/cloud-run-app/README.md
@@ -1,0 +1,48 @@
+# Cloud Run LLM Classifier
+
+Este ejemplo muestra una aplicación sencilla en Python que se ejecuta en Google Cloud Run y utiliza un modelo pequeño de lenguaje (LLM) para clasificar una descripción dentro de una de las diez categorías del sector automoción.
+
+## Despliegue rápido
+
+1. Construir la imagen Docker:
+   ```sh
+   docker build -t gcr.io/PROJECT_ID/cloud-run-llm .
+   ```
+2. Publicar en Google Container Registry:
+   ```sh
+   docker push gcr.io/PROJECT_ID/cloud-run-llm
+   ```
+3. Desplegar en Cloud Run:
+   ```sh
+   gcloud run deploy cloud-run-llm \
+     --image gcr.io/PROJECT_ID/cloud-run-llm \
+     --platform managed \
+     --region REGION \
+     --allow-unauthenticated
+   ```
+
+La aplicación expone el endpoint `/classify` que recibe una descripción en formato JSON:
+
+```json
+{
+  "description": "Necesito cambiar las pastillas de freno de mi coche"
+}
+```
+
+y devuelve la categoría estimada:
+
+```json
+{
+  "category": "Frenos"
+}
+```
+
+## Pruebas locales
+
+Se incluyen tests en `tests/` con conversaciones ficticias para comprobar que
+el servicio clasifica correctamente. Para ejecutarlos:
+
+```sh
+pip install -r requirements.txt pytest
+pytest
+```

--- a/cloud-run-app/app.py
+++ b/cloud-run-app/app.py
@@ -1,0 +1,53 @@
+from flask import Flask, request, jsonify
+from transformers import pipeline
+import os
+
+app = Flask(__name__)
+
+# Pre-defined automotive categories
+CATEGORIES = [
+    "Motor",
+    "Chasis",
+    "Electric",
+    "Mantenimiento",
+    "Frenos",
+    "Neumaticos",
+    "Carroceria",
+    "Electronica",
+    "Accesorios",
+    "Otros"
+]
+
+classifier = None
+
+
+def get_classifier():
+    """Lazily load the zero-shot classifier."""
+    global classifier
+    if classifier is None:
+        classifier = pipeline(
+            "zero-shot-classification",
+            model="valhalla/distilbart-mnli-12-1",
+        )
+    return classifier
+
+@app.route('/classify', methods=['POST'])
+def classify():
+    data = request.get_json(force=True)
+    text = data.get('description', '')
+    if not text:
+        return jsonify({'error': 'description is required'}), 400
+
+    clf = get_classifier()
+    result = clf(text, CATEGORIES)
+    # return the label with highest score
+    top_label = result['labels'][0]
+    return jsonify({'category': top_label})
+
+@app.route('/')
+def index():
+    return 'OK'
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', 8080))
+    app.run(host='0.0.0.0', port=port)

--- a/cloud-run-app/requirements.txt
+++ b/cloud-run-app/requirements.txt
@@ -1,0 +1,3 @@
+flask
+transformers
+torch

--- a/cloud-run-app/tests/test_app.py
+++ b/cloud-run-app/tests/test_app.py
@@ -1,0 +1,40 @@
+import json
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+class FakeClassifier:
+    def __call__(self, text, labels):
+        mapping = {
+            "Mi motor se ha sobrecalentado": {"labels": ["Motor"]},
+            "Quiero cambiar las llantas": {"labels": ["Neumaticos"]},
+            "Se ha roto el sistema electrico del coche": {"labels": ["Electric"]},
+        }
+        return mapping.get(text, {"labels": ["Otros"]})
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setattr('transformers.pipelines.pipeline', lambda *a, **k: FakeClassifier())
+    import app
+    with app.app.test_client() as client:
+        yield client
+
+def test_motor_category(client):
+    response = client.post('/classify', json={'description': 'Mi motor se ha sobrecalentado'})
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['category'] == 'Motor'
+
+def test_tire_category(client):
+    response = client.post('/classify', json={'description': 'Quiero cambiar las llantas'})
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['category'] == 'Neumaticos'
+
+def test_electric_category(client):
+    response = client.post('/classify', json={'description': 'Se ha roto el sistema electrico del coche'})
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['category'] == 'Electric'


### PR DESCRIPTION
## Summary
- load classifier lazily so tests can mock the pipeline
- add pytest-based tests with fake conversations
- document how to run tests locally

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851df495794832abd75fd657293949b